### PR TITLE
Implement AsyncCommandExecutor

### DIFF
--- a/qt-command-executor/AsyncCommandExecutor.h
+++ b/qt-command-executor/AsyncCommandExecutor.h
@@ -2,9 +2,6 @@
 #include <QProcess>
 #include <QProcessEnvironment>
 #include <QString>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonValue>
 #include <QVariant>
 #include <QQmlEngine>
 

--- a/qt-command-executor/AsyncCommandExecutor.h
+++ b/qt-command-executor/AsyncCommandExecutor.h
@@ -1,0 +1,164 @@
+#include <QObject>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QString>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QVariant>
+#include <QQmlEngine>
+
+
+class AsyncCommandExecutor : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString command WRITE setCommand READ getCommand)
+    Q_PROPERTY(QStringList arguments WRITE setArguments READ getArguments)
+    Q_PROPERTY(QVariantMap environment MEMBER m_environment)
+    Q_PROPERTY(bool running MEMBER m_running WRITE setRunning NOTIFY runningChanged)
+    Q_PROPERTY(int exitCode MEMBER m_exitCode NOTIFY exitCodeChanged)
+
+signals:
+    void runningChanged();
+    void exitCodeChanged();
+    void stdOutAvailable(const QString &output);
+    void stdErrAvailable(const QString &errors);
+
+public:
+    explicit AsyncCommandExecutor(QObject *parent = nullptr) : QObject(parent), m_command(""), m_arguments(), m_running(false), m_exitCode(-1) {
+        QObject::connect(&m_process, &QProcess::finished,
+                       this, &AsyncCommandExecutor::finished);
+        
+        m_process.setProcessChannelMode(QProcess::ForwardedChannels);
+    }
+
+    Q_INVOKABLE bool startCommand(int timeout = 30000)
+    {
+        if(m_running) {
+            qmlEngine(this)->throwError(tr("Command already running."));
+            return false;
+        }
+        
+        switch((QObject::receivers(SIGNAL(stdOutAvailable(const QString &))) > 0) * 2 + (QObject::receivers(SIGNAL(stdErrAvailable(const QString &))) > 0))
+        {
+            case 1:
+                m_process.setProcessChannelMode(QProcess::ForwardedOutputChannel);
+            break;
+            case 2:
+                m_process.setProcessChannelMode(QProcess::ForwardedErrorChannel);
+            break;
+            case 3:
+                m_process.setProcessChannelMode(QProcess::SeparateChannels);
+            break;
+        }
+        
+        QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+        env.remove("LD_PRELOAD");
+        for(auto iter = m_environment.begin(), end = m_environment.end(); iter != end; iter++)
+        {
+            auto value = iter.value().toString();
+            env.insert(iter.key(), value);
+        }
+        
+        m_process.setProcessEnvironment(env);
+        m_process.start();
+        
+        bool started = m_process.waitForStarted(timeout);
+        
+        if(started) {
+            m_running = true;
+            emit runningChanged();
+        }
+        
+        return started;
+    }
+    
+    Q_INVOKABLE bool terminateCommand(int timeout = 30000)
+    {
+        if(!m_running)
+            return true;
+        
+        m_process.terminate();
+        
+        if(timeout != 0)
+            return m_process.waitForFinished(timeout);
+        else
+            return !m_running;
+    }
+    
+    void setRunning(bool new_running) {
+        if(new_running == true && m_running == false)
+        {
+            bool started = startCommand(100);
+            if(!started)
+            {
+                qmlEngine(this)->throwError(tr("Command did not start successfully."));
+            }
+        }
+        else if(new_running == false && m_running == true)
+        {
+            bool ended = terminateCommand(100);
+            if(!ended)
+            {
+                qmlEngine(this)->throwError(tr("Command did not terminate."));
+            }
+        }
+    }
+    
+    QString getCommand() const {
+        return m_process.program();
+    }
+    
+    void setCommand(const QString& new_command) {
+        m_process.setProgram(new_command);
+    }
+    
+    QStringList getArguments() const {
+        return m_process.arguments();
+    }
+    
+    void setArguments(const QStringList& new_arguments) {
+        m_process.setArguments(new_arguments);
+    }
+
+private:
+    QString m_command;
+    QStringList m_arguments;
+    QVariantMap m_environment;
+    bool m_running;
+    int m_exitCode;
+    
+    QProcess m_process;
+
+private slots:
+    void finished(int exitCode, QProcess::ExitStatus exitStatus) {
+        m_running = false;
+        
+        if(exitStatus == QProcess::NormalExit) 
+        {
+            m_exitCode = exitCode;
+        }
+        else
+        {
+            m_exitCode = -m_process.error() -1;
+        }
+        
+        QByteArray read_data = m_process.readAllStandardError();
+        if(read_data.length() > 0)
+        {
+            QString read_string(read_data);
+            emit stdErrAvailable(read_string);
+        }
+        
+        read_data = m_process.readAllStandardOutput();
+        if(read_data.length() > 0)
+        {
+            QString read_string(read_data);
+            emit stdOutAvailable(read_string);
+        }
+        
+        emit runningChanged();
+        emit exitCodeChanged();
+    }
+};
+

--- a/qt-command-executor/AsyncCommandExecutor.h
+++ b/qt-command-executor/AsyncCommandExecutor.h
@@ -25,6 +25,8 @@ public:
     explicit AsyncCommandExecutor(QObject *parent = nullptr) : QObject(parent), m_command(""), m_arguments(), m_running(false), m_exitCode(-1) {
         QObject::connect(&m_process, &QProcess::finished,
                        this, &AsyncCommandExecutor::finished);
+        QObject::connect(&m_process, &QProcess::channelReadyRead,
+                       this, &AsyncCommandExecutor::ioAvailable);
         
         m_process.setProcessChannelMode(QProcess::ForwardedChannels);
     }
@@ -156,6 +158,34 @@ private slots:
         
         emit runningChanged();
         emit exitCodeChanged();
+    }
+
+    void ioAvailable(int channel)
+    {
+      while(channel == QProcess::StandardOutput && m_process.canReadLine())
+      {
+          QByteArray read_data = m_process.readLine().trimmed();
+          if(read_data.length() > 0)
+          {
+              QString read_string(read_data);
+              emit stdOutAvailable(read_string);
+          }
+      }
+
+      if(channel == QProcess::StandardError)
+      {
+          m_process.setReadChannel(QProcess::StandardError);
+          while(m_process.canReadLine())
+          {
+              QByteArray read_data = m_process.readLine().trimmed();
+              if(read_data.length() > 0)
+              {
+                  QString read_string(read_data);
+                  emit stdErrAvailable(read_string);
+              }
+          }
+          m_process.setReadChannel(QProcess::StandardOutput);
+      }
     }
 };
 

--- a/qt-command-executor/main.cpp
+++ b/qt-command-executor/main.cpp
@@ -4,10 +4,11 @@
 #include <QQmlApplicationEngine>
 #include <dlfcn.h>
 #include "CommandExecutor.h"
-
+#include "AsyncCommandExecutor.h"
 
 extern "C" void _xovi_construct(){
     qmlRegisterType<CommandExecutor>("net.asivery.CommandExecutor", 1, 0, "CommandExecutor");
+    qmlRegisterType<AsyncCommandExecutor>("net.asivery.CommandExecutor", 1, 0, "AsyncCommandExecutor");
 }
 
 extern "C" char _xovi_shouldLoad() {

--- a/qt-command-executor/qt-command-executor.pro
+++ b/qt-command-executor/qt-command-executor.pro
@@ -12,7 +12,7 @@ CONFIG += c++11
 # Specify the source files
 SOURCES += main.cpp
 
-HEADERS += CommandExecutor.h
+HEADERS += CommandExecutor.h AsyncCommandExecutor.h
 
 QMAKE_CXXFLAGS += -fPIC 
 


### PR DESCRIPTION
This PR adds a component AsyncCommandExecutor that can be user to run child processes from QML without freezing the GUI.

Please note: In my tests, output received in the signal stdOutAvailable is sometimes truncated, i.e. the last few characters might be missing. I do not know why this is. Any pointers and further testing would be welcome.