### PR TITLE
Add PATH variable to be identical to when run by systemd

### DIFF
--- a/xovi-setup/rebuild_hashtable
+++ b/xovi-setup/rebuild_hashtable
@@ -44,6 +44,7 @@ echo
 QMLDIFF_HASHTAB_CREATE="$hashtab" \
 QML_DISABLE_DISK_CACHE=1 \
 LD_PRELOAD="$xovi_so" \
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin \
 /usr/bin/xochitl 2>&1 | while IFS= read -r line; do
     echo -e "$line"
 


### PR DESCRIPTION
This change is necessary for me on RM2 with 3.27.1.0, otherwise the `rebuild_hashtable` script crashes the device and the table is not successfully built.
Running `/usr/bin/xochitl` from the shell failed the same way, and when inspecting what was different between it and the systemd service I found setting the PATH variable fixes it.

Since this is an entirely inoffensive change, I don't think it can hurt to incorporate it to save others the same headache.